### PR TITLE
[DLAB-9932] Allows Guzzle ^7.0 and Monolog ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "eresponseservices/mastercard-sdk-core-php": "dev-feature/DLAB-9932"
+        "eresponseservices/mastercard-sdk-core-php": "1.5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.5"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "eresponseservices/mastercard-sdk-core-php": ">=1.4.11 <1.5.0"
+        "eresponseservices/mastercard-sdk-core-php": "dev-feature/DLAB-9932"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.5"


### PR DESCRIPTION
[Ticket DLAB-9932](https://chargebacks911.atlassian.net/browse/DLAB-9932)

Related PRs:

- **⚠️ it depends on:**
    1. https://github.com/eresponseservices/mastercard-sdk-core-php/pull/6
- this PR is a dependency of:     
  - 1. `drm-scheme` https://github.com/eresponseservices/drm-scheme/pull/338
  
 ### Description

Allows new versions of guzzle and monolog.